### PR TITLE
updating the required compiler version to 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,8 +157,8 @@ governing permissions and limitations under the License. -->
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Building with 1.6 yields the error: class file for java.lang.AutoCloseable not found

The error message produced with this change points a bit more directly to the fact that the wrong JDK is being used.