### PR TITLE
Fixed plug-in type in configuration.

### DIFF
--- a/src/main/java/io/fabric8/elasticsearch/plugin/cloud/k8s/CloudK8sPlugin.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/cloud/k8s/CloudK8sPlugin.java
@@ -1,0 +1,27 @@
+package io.fabric8.elasticsearch.plugin.cloud.k8s;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.AbstractPlugin;
+
+/**
+ *
+ */
+public class CloudK8sPlugin extends AbstractPlugin {
+
+  private final Settings settings;
+
+  public CloudK8sPlugin(Settings settings) {
+    this.settings = settings;
+  }
+
+  @Override
+  public String name() {
+    return "cloud-kubernetes";
+  }
+
+  @Override
+  public String description() {
+    return "Cloud Kubernetes Plugin";
+  }
+
+}

--- a/src/main/resources/es-plugin.properties
+++ b/src/main/resources/es-plugin.properties
@@ -1,0 +1,2 @@
+plugin=io.fabric8.elasticsearch.plugin.cloud.k8s.CloudK8sPlugin
+version=${project.version}


### PR DESCRIPTION
This was what was going on:
```
- NoClassSettingsException[Failed to load class setting [discovery.type] with value [io.fabric8.elasticsearch.discovery.k8s.K8sDiscoveryModuley]]
	ClassNotFoundException[io.fabric8.elasticsearch.discovery.k8s.k8sdiscoverymoduley.K8sDiscoveryModuleyDiscoveryModule]
```