### PR TITLE
Upgrade to Elasticsearch 1.5.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,9 +47,9 @@ governing permissions and limitations under the License. -->
   </issueManagement>
 
   <properties>
-    <elasticsearch.version>1.4.4</elasticsearch.version>
     <fabric8.version>2.0.29</fabric8.version>
-    <lucene.version>4.10.3</lucene.version>
+    <elasticsearch.version>1.5.0</elasticsearch.version>
+    <lucene.version>4.10.4</lucene.version>
     <tests.shuffle>true</tests.shuffle>
     <tests.output>onerror</tests.output>
     <tests.client.ratio />

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@ governing permissions and limitations under the License. -->
   </issueManagement>
 
   <properties>
-    <fabric8.version>2.0.29</fabric8.version>
     <elasticsearch.version>1.5.0</elasticsearch.version>
+    <fabric8.version>2.0.34</fabric8.version>
     <lucene.version>4.10.4</lucene.version>
     <tests.shuffle>true</tests.shuffle>
     <tests.output>onerror</tests.output>

--- a/src/main/java/io/fabric8/elasticsearch/discovery/k8s/K8sDiscovery.java
+++ b/src/main/java/io/fabric8/elasticsearch/discovery/k8s/K8sDiscovery.java
@@ -3,6 +3,7 @@ package io.fabric8.elasticsearch.discovery.k8s;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterService;
 import org.elasticsearch.cluster.node.DiscoveryNodeService;
+import org.elasticsearch.cluster.settings.DynamicSettings;
 import org.elasticsearch.common.collect.ImmutableList;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.network.NetworkService;
@@ -27,9 +28,9 @@ public class K8sDiscovery extends ZenDiscovery {
                       ClusterService clusterService, NodeSettingsService nodeSettingsService, ZenPingService pingService,
                       DiscoveryNodeService discoveryNodeService,
                       NetworkService networkService, DiscoverySettings discoverySettings,
-                      ElectMasterService electMasterService) {
+                      ElectMasterService electMasterService, DynamicSettings dynamicSettings) {
     super(settings, clusterName, threadPool, transportService, clusterService, nodeSettingsService,
-        discoveryNodeService, pingService, electMasterService, discoverySettings);
+        discoveryNodeService, pingService, electMasterService, discoverySettings, dynamicSettings);
     if (settings.getAsBoolean("cloud.enabled", true)) {
       ImmutableList<? extends ZenPing> zenPings = pingService.zenPings();
       UnicastZenPing unicastZenPing = null;


### PR DESCRIPTION
This breaks compatibility with versions prior to 1.5.0, so one must be sure to updated `README.md` to include something like
```
## Version 1.0.3 for Elasticsearch: 1.4.4
## Version 1.0.4 for Elasticsearch: 1.5.0+
```
