### PR TITLE
Docker image improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ discovery:
 path:
   data: /data/data
   logs: /data/log
-  plugins: /data/plugins
+  plugins: /elasticsearch/plugins
   work: /data/work
 ```
 
@@ -148,7 +148,7 @@ The DNS lookup is on the headless service name so that all existing nodes from t
               "containers": [
                 {
                   "name": "elasticsearch-container",
-                  "image": "fabric8/elasticsearch-k8s:1.5.0",
+                  "image": "fabric8/elasticsearch-k8s:1.5.2",
                   "imagePullPolicy": "PullIfNotPresent",
                   "env": [
                     {
@@ -212,7 +212,7 @@ The DNS lookup is on the headless service name so that all existing nodes from t
               "containers": [
                 {
                   "name": "elasticsearch-container",
-                  "image": "fabric8/elasticsearch-k8s:1.5.0",
+                  "image": "fabric8/elasticsearch-k8s:1.5.2",
                   "imagePullPolicy": "PullIfNotPresent",
                   "env": [
                     {
@@ -269,7 +269,7 @@ The DNS lookup is on the headless service name so that all existing nodes from t
               "containers": [
                 {
                   "name": "elasticsearch-container",
-                  "image": "fabric8/elasticsearch-k8s:1.5.0",
+                  "image": "fabric8/elasticsearch-k8s:1.5.2",
                   "imagePullPolicy": "PullIfNotPresent",
                   "env": [
                     {

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -9,4 +9,4 @@ discovery:
   type: io.fabric8.elasticsearch.discovery.k8s.K8sDiscoveryModule
 
 path:
-  plugins: /usr/share/elasticsearch/plugins
+  plugins: /elasticsearch/plugins

--- a/elasticsearch.yml
+++ b/elasticsearch.yml
@@ -7,6 +7,13 @@ cloud:
 
 discovery:
   type: io.fabric8.elasticsearch.discovery.k8s.K8sDiscoveryModule
+  zen:
+    ping:
+      multicast:
+        enabled: false
 
 path:
   plugins: /elasticsearch/plugins
+
+bootstrap:
+  mlockall: true

--- a/pom.xml
+++ b/pom.xml
@@ -289,10 +289,10 @@ governing permissions and limitations under the License. -->
             <image>
               <name>docker.io/fabric8/elasticsearch-k8s:${elasticsearch.version}</name>
               <build>
-                <from>elasticsearch:${elasticsearch.version}</from>
+                <from>quay.io/pires/docker-elasticsearch:${elasticsearch.version}</from>
                 <assembly>
                   <descriptor>${basedir}/src/main/assemblies/docker-image.xml</descriptor>
-                  <basedir>/usr/share/elasticsearch/</basedir>
+                  <basedir>/elasticsearch</basedir>
                 </assembly>
                 <env>
                   <NODE_DATA>true</NODE_DATA>


### PR DESCRIPTION
* 205MB uncompressed
* `busybox` + Oracle JRE 8u45
* Elasticsearch 1.5.2
* Added some Elasticsearch configuration best-pratices
  * Disabled multicast discovery
  * Enabled [`mlockall`](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-configuration.html#setup-configuration-memory)