### PR TITLE
need a 2.x branch or a 2.4 branch in order to have this 2.4.4 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Kubernetes Cloud plugin allows to use Kubernetes API for the unicast discove
 Installation
 ============
 ```
-plugin install io.fabric8/elasticsearch-cloud-kubernetes/2.4.1
+plugin install io.fabric8/elasticsearch-cloud-kubernetes/2.4.4
 ```
 
 Versions available
@@ -147,7 +147,7 @@ items:
                     fieldPath: "metadata.namespace"
               - name: "NODE_MASTER"
                 value: "false"
-            image: "fabric8/elasticsearch-k8s:2.4.1"
+            image: "fabric8/elasticsearch-k8s:2.4.4"
             name: "elasticsearch"
             ports:
               - containerPort: 9300
@@ -189,7 +189,7 @@ items:
                     fieldPath: "metadata.namespace"
               - name: "NODE_DATA"
                 value: "false"
-            image: "fabric8/elasticsearch-k8s:2.4.1"
+            image: "fabric8/elasticsearch-k8s:2.4.4"
             name: "elasticsearch"
             ports:
               - containerPort: 9300
@@ -225,7 +225,7 @@ items:
                 value: "false"
               - name: "NODE_MASTER"
                 value: "false"
-            image: "fabric8/elasticsearch-k8s:2.4.1"
+            image: "fabric8/elasticsearch-k8s:2.4.4"
             name: "elasticsearch"
             ports:
               - containerPort: 9200

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.fabric8</groupId>
   <artifactId>elasticsearch-cloud-kubernetes</artifactId>
-  <version>2.4.1</version>
+  <version>2.4.4</version>
 
   <name>Elasticsearch Kubernetes cloud plugin</name>
   <description>The Kubernetes Cloud plugin allows to use Kubernetes for the unicast discovery mechanism.</description>
@@ -44,7 +44,7 @@
     <connection>scm:git:git@github.com:fabric8io/elasticsearch-cloud-kubernetes.git</connection>
     <developerConnection>scm:git:git@github.com:fabric8io/elasticsearch-cloud-kubernetes.git</developerConnection>
     <url>http://github.com/fabric8io/elasticsearch-cloud-kubernetes</url>
-    <tag>elasticsearch-cloud-kubernetes-2.4.1</tag>
+    <tag>elasticsearch-cloud-kubernetes-2.4.4</tag>
   </scm>
 
   <issueManagement>
@@ -54,7 +54,7 @@
 
   <properties>
     <elasticsearch.plugin.name>cloud-kubernetes</elasticsearch.plugin.name>
-    <elasticsearch.version>2.4.1</elasticsearch.version>
+    <elasticsearch.version>2.4.4</elasticsearch.version>
     <kubernetes-client.version>1.3.83</kubernetes-client.version>
     <lucene.version>5.5.2</lucene.version>
     <tests.shuffle>true</tests.shuffle>


### PR DESCRIPTION
This won't merge because it needs a separate 2.x or 2.4 branch to merge into and release from.  This patch is based off of the elasticsearch-cloud-kubernetes-2.4.1 tag.