### PR TITLE
Fix data volume mounting by running the image as root user.

### DIFF
--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -52,7 +52,6 @@ VOLUME /usr/share/elasticsearch/data
 
 COPY docker-entrypoint.sh /
 
-USER 1001
 EXPOSE 9200 9300
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["elasticsearch"]


### PR DESCRIPTION
Running the image as elasticsearch user skips the data directory chown in docker-entrypoint.sh. This causes an issue when mounting the data directory as external volume - ES doesn't have permissions to the data directory and node setup fails. 

After the fix, ES is still run as elasticsearch user inside the container.