### PR TITLE
Update to ES 6.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Alternatively, you can utilize [headless services](https://kubernetes.io/docs/co
         component: es
       sessionAffinity: None
       type: ClusterIP
- 
+
  elasticsearch.yml:
 
     ...
@@ -37,7 +37,7 @@ Alternatively, you can utilize [headless services](https://kubernetes.io/docs/co
 Installation
 ============
 ```
-elasticsearch-plugin install io.fabric8:elasticsearch-cloud-kubernetes:6.2.3.2
+elasticsearch-plugin install io.fabric8:elasticsearch-cloud-kubernetes:6.2.4
 
 ```
 
@@ -175,7 +175,7 @@ items:
               - name: "NODE_MASTER"
                 value: "false"
 
-            image: "fabric8/elasticsearch-k8s:6.2.3"
+            image: "fabric8/elasticsearch-k8s:6.2.4"
             name: "elasticsearch"
             ports:
               - containerPort: 9300
@@ -218,7 +218,7 @@ items:
               - name: "NODE_DATA"
                 value: "false"
 
-            image: "fabric8/elasticsearch-k8s:6.2.3"
+            image: "fabric8/elasticsearch-k8s:6.2.4"
             name: "elasticsearch"
             ports:
               - containerPort: 9300
@@ -254,7 +254,7 @@ items:
                 value: "false"
               - name: "NODE_MASTER"
                 value: "false"
-            image: "fabric8/elasticsearch-k8s:6.2.3"
+            image: "fabric8/elasticsearch-k8s:6.2.4"
             name: "elasticsearch"
             ports:
               - containerPort: 9200

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
   <properties>
     <elasticsearch.plugin.name>discovery-kubernetes</elasticsearch.plugin.name>
-    <elasticsearch.version>6.2.3</elasticsearch.version>
+    <elasticsearch.version>6.2.4</elasticsearch.version>
     <kubernetes-client.version>1.4.35</kubernetes-client.version>
     <tests.shuffle>true</tests.shuffle>
     <tests.output>onerror</tests.output>

--- a/src/main/docker/Dockerfile
+++ b/src/main/docker/Dockerfile
@@ -28,7 +28,7 @@ RUN set -x \
   && chmod +x /usr/local/bin/gosu \
   && gosu nobody true
 
-ENV ELASTICSEARCH_VERSION 6.2.3
+ENV ELASTICSEARCH_VERSION 6.2.4
 
 RUN set -x \
   && cd /usr/share \


### PR DESCRIPTION
This PR updates the plugin to latest ES version. As you may find on [ES releases notes](https://www.elastic.co/guide/en/elasticsearch/reference/current/es-release-notes.html), a new version is available.

The related error is:
```
elastic INFO  Installing plugin:  io.fabric8:elasticsearch-cloud-kubernetes:6.2.3.2
Error executing 'postInstallation': Exception in thread "main" java.lang.IllegalArgumentException: plugin [discovery-kubernetes] is incompatible with version [6.2.4]; was designed for version [6.2.3]
	at org.elasticsearch.plugins.PluginInfo.readFromProperties(PluginInfo.java:237)
	at org.elasticsearch.plugins.PluginInfo.readFromProperties(PluginInfo.java:184)
	at org.elasticsearch.plugins.InstallPluginCommand.loadPluginInfo(InstallPluginCommand.java:571)
	at org.elasticsearch.plugins.InstallPluginCommand.installPlugin(InstallPluginCommand.java:707)
	at org.elasticsearch.plugins.InstallPluginCommand.install(InstallPluginCommand.java:623)
	at org.elasticsearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:223)
	at org.elasticsearch.plugins.InstallPluginCommand.execute(InstallPluginCommand.java:212)
	at org.elasticsearch.cli.EnvironmentAwareCommand.execute(EnvironmentAwareCommand.java:86)
	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:124)
	at org.elasticsearch.cli.MultiCommand.execute(MultiCommand.java:75)
	at org.elasticsearch.cli.Command.mainWithoutErrorHandling(Command.java:124)
	at org.elasticsearch.cli.Command.main(Command.java:90)
	at org.elasticsearch.plugins.PluginCli.main(PluginCli.java:48)
```